### PR TITLE
Replace "[creature]" with "A card bearing this sigil"

### DIFF
--- a/Scripts/ReadmeDump.cs
+++ b/Scripts/ReadmeDump.cs
@@ -203,12 +203,12 @@ namespace ReadmeMaker
 	        return list;
         }
 
-		// In-game, when the rulebook description for a sigil is being displyed all instances of "[creature]" are replaced with "A card bearing this sigil".
-		// We do this when generating the readme as well for the sake of consistency.
-		private static string ParseAbilityInfo(string desc)
-		{
-			return desc.Replace("[creature]", "A card bearing this sigil");
-		}
+	// In-game, when the rulebook description for a sigil is being displyed all instances of "[creature]" are replaced with "A card bearing this sigil".
+	// We do this when generating the readme as well for the sake of consistency.
+	private static string ParseAbilityInfo(string desc)
+	{
+		return desc.Replace("[creature]", "A card bearing this sigil");
+	}
 
         private static string GetAbilityInfo(NewAbility newAbility)
         {

--- a/Scripts/ReadmeDump.cs
+++ b/Scripts/ReadmeDump.cs
@@ -203,9 +203,14 @@ namespace ReadmeMaker
 	        return list;
         }
 
+		private static string ParseAbilityInfo(string desc)
+		{
+			return desc.Replace("[creature]", "A card bearing this sigil");
+		}
         private static string GetAbilityInfo(NewAbility newAbility)
         {
-	        return $" - **{newAbility.info.rulebookName}** - {newAbility.info.rulebookDescription}";
+			string desc = ParseAbilityInfo(newAbility.info.rulebookDescription);
+	        return $" - **{newAbility.info.rulebookName}** - {desc}";
         }
 
         private static string GetSpecialAbilityInfo(NewSpecialAbility newAbility)

--- a/Scripts/ReadmeDump.cs
+++ b/Scripts/ReadmeDump.cs
@@ -203,12 +203,16 @@ namespace ReadmeMaker
 	        return list;
         }
 
+		// In-game, when the rulebook description for a sigil is being displyed all instances of "[creature]" are replaced with "A card bearing this sigil".
+		// We do this when generating the readme as well for the sake of consistency.
 		private static string ParseAbilityInfo(string desc)
 		{
 			return desc.Replace("[creature]", "A card bearing this sigil");
 		}
+
         private static string GetAbilityInfo(NewAbility newAbility)
         {
+			// Seeing "[creature]" appear in the readme looks jarring, sigil descriptions should appear exactly as they do in the rulebook for consistency
 			string desc = ParseAbilityInfo(newAbility.info.rulebookDescription);
 	        return $" - **{newAbility.info.rulebookName}** - {desc}";
         }


### PR DESCRIPTION
In-game, sigil descriptions are parsed to replace "[creature]" with "A card bearing this sigil" in acts 1/3, and the card's name in act 2. However, this parsing is not carried over in the readme generator; instead using the raw, unparsed descriptions of sigils.

This PR changes the sigil section of the readme generator to replace all instances of "[creature]" with "A card bearing this sigil" in sigil descriptions.